### PR TITLE
Remove a redundant constraint in BigAddModP

### DIFF
--- a/circuits/bigint.circom
+++ b/circuits/bigint.circom
@@ -614,7 +614,8 @@ template BigAddModP(n, k){
     sub.a[k] <== add.out[k];
     sub.b[k] <== 0;
     
-    sub.out[k] === 0;
+    // the following constraint can be implied
+    // sub.out[k] === 0;
     for (var i = 0; i < k; i++) {
         out[i] <== sub.out[i];
     }


### PR DESCRIPTION
Since 0<= a,b < p, 0<= add.out < 2p. (1) If 0 <= add.out < p, lt.out = 1 and sub.out = add.out, which means that 0 <= sub.out < p. (2) If p <= add.out < 2p, lt.out = 0 and sub.out = add.out - p, which also means that 0 <= sub.out < p. And because p is a bigint of length k, sub.out[k] must be 0.